### PR TITLE
Add by-laws

### DIFF
--- a/by-laws.html
+++ b/by-laws.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title>UMEC: By-laws</title>
+    <!-- @include includes/head.html -->
+  </head>
+  <body>
+    <!-- @include includes/header.html -->
+    <div class='content'>
+      <h1>UMEC By-laws</h1>
+      <!-- @include content/by-laws.html -->
+    </div>
+  </body>
+</html>

--- a/content/by-laws.md
+++ b/content/by-laws.md
@@ -1,0 +1,607 @@
+**Table of Contents** 
+
+- [Article I: MEMBERSHIP AND VOTING PRIVILEGES](#article-i-membership-and-voting-privileges)
+  - [Section 1:  UMEC Membership](#section-1--umec-membership)
+  - [Section 2:  Tenure Membership](#section-2--tenure-membership)
+  - [Section 3: Society Membership](#section-3-society-membership)
+- [Article II: UMEC MEETINGS](#article-ii-umec-meetings)
+  - [Section 1:](#section-1)
+  - [Section 2:](#section-2)
+  - [Section 3:](#section-3)
+  - [Section 4:](#section-4)
+- [Article III: ELECTION OF EXECUTIVE OFFICERS](#article-iii-election-of-executive-officers)
+  - [Section 1:](#section-1-1)
+  - [Section 2:](#section-2-1)
+  - [Section 3:](#section-3-1)
+  - [Section 4 : Candidates and Schedule](#section-4--candidates-and-schedule)
+  - [Section 5: Schedule and Mechanics of Executive Board Elections](#section-5-schedule-and-mechanics-of-executive-board-elections)
+  - [Section 6: Occurrence of an empty position on ballot](#section-6-occurrence-of-an-empty-position-on-ballot)
+  - [Section 7: Post Election Procedures](#section-7-post-election-procedures)
+- [Article V: OFFICERS](#article-v-officers)
+  - [Section 1: President](#section-1-president)
+  - [Section 2: Vice President](#section-2-vice-president)
+  - [Section 3: Director of Leadership](#section-3-director-of-leadership)
+  - [Section 4: Director of Administration](#section-4-director-of-administration)
+  - [Section 5: Director of Corporate Affairs](#section-5-director-of-corporate-affairs)
+  - [Section 6: Director of Finance](#section-6-director-of-finance)
+  - [Section 7: Director of Student Affairs](#section-7-director-of-student-affairs)
+  - [Section 8: Director of Publicity](#section-8-director-of-publicity)
+  - [Section 9: Director of Social Affairs](#section-9-director-of-social-affairs)
+  - [Section 10: Director of Honors and Service](#section-10-director-of-honors-and-service)
+  - [Section 11: NAESC, Inc. Exec Board Members](#section-11-naesc-inc-exec-board-members)
+- [Article VI: COMMITTEES](#article-vi-committees)
+  - [Section 1:  Engineering Leadership Committee (ELC)](#section-1--engineering-leadership-committee-elc)
+  - [Section 2:  Student Affairs Committee](#section-2--student-affairs-committee)
+  - [Section 3:  Engineering Council Honors and Service Committee](#section-3--engineering-council-honors-and-service-committee)
+  - [Section 4:  Engineering Council Publicity Committee](#section-4--engineering-council-publicity-committee)
+  - [Section 5:  Engineering Council Social Affairs Committee](#section-5--engineering-council-social-affairs-committee)
+  - [Section 6:  Engineering Council Representative Committee](#section-6--engineering-council-representative-committee)
+- [Article VIII: MEMBER SOCIETY OBLIGATIONS](#article-viii-member-society-obligations)
+  - [Society Representative](#society-representative)
+  - [General Meetings](#general-meetings)
+  - [Communication](#communication)
+  - [Probation and Suspension](#probation-and-suspension)
+- [Article IX: MEMBER SOCIETY PROBATION/SUSPENSION](#article-ix-member-society-probationsuspension)
+  - [Section 1:](#section-1-2)
+- [Article X: BUDGETARY PROCEDURES](#article-x-budgetary-procedures)
+  - [Section 1:](#section-1-3)
+  - [Section 2:](#section-2-2)
+  - [Section 3:](#section-3-2)
+- [Article XI: FUNDING POLICY](#article-xi-funding-policy)
+  - [Section 1: Eligibility](#section-1-eligibility)
+  - [Section 2:](#section-2-3)
+  - [Section 3: The Funding Committee](#section-3-the-funding-committee)
+- [Article XII: MICHIGAN STUDENT ASSEMBLY](#article-xii-michigan-student-assembly)
+  - [Section 1: Tenure](#section-1-tenure)
+- [Article XIII: INSIGNIA](#article-xiii-insignia)
+  - [Section 1: Use of the UMEC Name](#section-1-use-of-the-umec-name)
+  - [Section 2: UMEC Seal](#section-2-umec-seal)
+  - [Section 3: UMEC Logo](#section-3-umec-logo)
+- [Article XIV: AMENDMENTS](#article-xiv-amendments)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Article I: MEMBERSHIP AND VOTING PRIVILEGES
+
+## Section 1:  UMEC Membership
+
+Membership shall be restricted to Engineering Students.  An Engineering Student shall be defined as any student in the following majors:
+
+- College of Engineering:  Any major
+- LSA:  Computer Science
+- Rackham: Engineering programs
+
+Membership may be granted at the discretion of the President
+
+## Section 2:  Tenure Membership
+
+Tenure shall be defined as the right to vote, acquired by attendance at two of any three consecutive Council meetings. Tenure may also be obtained by the membership-at-large with the attendance at the first meeting of the term.
+
+Tenure will be immediately given to a society representative upon recognition of that society by the Council.
+
+Tenure shall be lost by a voting student representative if he/she should miss two consecutive Council meetings.
+
+Tenure is not strictly monitored, but is based on the Honor System and the Council expects that all societies and members-at-large will abide by the system.
+
+Tenure shall be granted to all qualified students under Article I for the Executive Board elections.
+
+A student organization representative may change his/her status to that of a member-at-large and gain immediate tenure under two conditions: (1) he/she notifies the Vice President of the new society representative taking his/her place and (2) the organization he/she represents must have tenure at the time of the status change. The new representative must attend all future Council meetings in order for that society to maintain tenure.  
+
+## Section 3: Society Membership
+
+Any engineering society may be recognized by the Council by fulfilling the following requirements:
+
+- Consisting of at least 50 (fifty) percent College of Engineering students. 
+- Holding regular and publicized meetings. 
+- Having at least two officers and holding elections at least once per school year. 
+- Having a constitution detailing the purpose of the society. 
+- Organization registered with The Center for Campus Involvement.
+- A society will lose its recognition if it does not meet any one of the requirements 1 through 5 as stated above.
+
+Recognized societies' Representatives are expected to maintain tenure by attending all UMEC General Meetings and should report back to their society on Council business.
+
+Recognized societies are expected to send a Representative to the Engineering Student Organization Retreat each semester.
+
+Only societies recognized by the Engineering Council according to the requirements will be considered for allocations.
+
+Membership of organizations may be granted, revoked, or reinstated subject to a two-thirds majority vote of those general council members present and voting not including the engineering organization under consideration.
+
+Each society shall have registered with the Vice President the names of (and means of contacting) their Engineering Council representative, their president, and their faculty advisor.
+
+To ensure that the society maintains a vote on the Engineering Council, the president of each represented society shall notify the Vice President of the Engineering Council, in writing, concerning any change in the identity of their society’s representative, president, or faculty advisor.
+
+# Article II: UMEC MEETINGS
+
+## Section 1:
+
+The presiding officer shall be the President of the council.
+
+## Section 2:
+
+In the absence of the President, the succession of presiding officer shall be the order as presented in Article III, Section 2 in the UMEC Constitution.
+
+## Section 3:
+
+General meetings of the Engineering Council shall be held a minimum of six times a semester during the fall and winter semesters.
+
+## Section 4:
+
+The presiding officer shall serve as Parliamentarian at all Engineering Council meetings.
+
+# Article III: ELECTION OF EXECUTIVE OFFICERS
+
+## Section 1:
+
+All Executive Board Officers shall be elected by the first General Body meeting of the Engineering Council every winter semester.
+
+## Section 2:
+
+The Vice President shall be responsible for organizing the election in conjunction with the CSG Fall Elections in the Fall Term. The General Council may extend the period of the election and/or move the dates of the election by a majority vote.  Officers shall be elected by a majority of those voting.
+
+## Section 3:
+
+All College of Engineering students are eligible to vote for Executive Board Officers.
+
+## Section 4 : Candidates and Schedule
+
+Filing Deadline: The deadline for filing as a candidate and submitting other pertinent information shall be announced at a General Body meeting and published at least two weeks before the filing deadline.
+
+The Statement of Intent: A statement of intent must be turned in to the Elections Chairperson at least one week prior to the elections for the candidate's name to appear on the ballot. The statement of intent shall include:
+
+- Name as the candidate wishes it to appear on the ballot (subject to the approval of Elections Chairperson), 
+- Name as registered with the Registrar, 
+- E-mail address,
+- College department and class, 
+- Office for which the candidate wishes to run, 
+- Student ID number,
+
+## Section 5: Schedule and Mechanics of Executive Board Elections
+
+The meeting with the Executive Board Elections shall be referred to as the Executive Board Elections meeting.
+
+No elections personnel shall be a candidate in the election.
+
+If the Vice President is unable to act as the Executive Board Elections Chairperson, the President shall appoint an Executive Board member to act as the Elections Chairperson.
+
+Election Publicity: The Director of Publicity shall be responsible for publicizing the election of the Executive Officers to all students in the College of Engineering at least a week prior to the election. Information to include in publicity is dates of election, candidates running, and website address to visit in order to submit your vote. Methods of publicity can include mass email(s) to the college and/or flyering North Campus.
+
+Campaigning Limit: Candidates may not conduct any public campaigning for themselves until a week away from the election. Any publicized campaigning can only show support for a candidate and cannot say anything negative about other candidates running. Acceptable methods of publicity include email(s) to friends/ peers and flyering North Campus.
+
+Election and Campaign Procedures: Elections and campaign procedures will be the responsibility of the Elections Chairperson.
+
+Electronic Ballot: Since the elections are held in conjunction with the MSA Elections, the Election Chairperson shall be responsible for turning the names of all certified candidates to the UM Webmaster Election team.
+
+Counting Electronic Ballots: The Election Chairperson shall arrange to receive the vote totals of all positions from the UM Webmaster Election team.
+
+## Section 6: Occurrence of an empty position on ballot
+
+If there is no candidate on the ballot for a given Executive Board position, write-in votes are welcome.
+
+The Election Chair will contact all individuals who receive write-in votes for the position. These individuals need to respond to the Elections Chair within 24 hours to give their interest (or disinterest) in running for the position. If no response is given, then the Elections Chair will assume the individual isn’t interested.
+
+The Election Chair will tally the scores of all the write-in candidates that showed interest in running for that position and the one with the most write-in votes will be elected to that position. 
+## Section 7: Post Election Procedures
+
+Upon receiving the election results, the Election Chairperson must immediately inform the entire student body in the College of Engineering of the election results in a published report no more than three days after the elections. The report shall include:
+
+- Results of the election including names of the candidates and the number of votes cast for each candidate. 
+
+# Article V: OFFICERS
+
+## Section 1: President
+
+Shall oversee all Engineering Council activities.
+
+Shall call Engineering Council and Executive Board meetings as deemed necessary.
+
+Shall chair all said meetings and shall remove himself from the chair when expressing any opinion on the business at hand.
+
+Shall have final interpretation of the Constitution and Bylaws.
+
+Shall be responsible for making sure that agendas are made for each Executive Board meeting.
+
+Shall have at least one organizational meeting with the new executive officers within two weeks of officer elections.
+
+Shall act as an official representative of the Engineering Council.
+
+Shall make certain that a history of Engineering Council events is preserved.
+
+Shall be responsible for the understanding of the Constitution, Bylaws, policies and guidelines of the Engineering Council by the Executive Board.
+
+Shall be responsible for the revision of the Engineering Council Constitution.
+
+## Section 2: Vice President
+
+Shall assist the President and assume the duties of the President in the President’s absence
+
+Shall organize general meetings.
+
+Shall be in charge of communicating Council business to the member societies.
+
+Shall encourage idea-sharing and ensure the availability of a forum for inter-society communication and collaboration.
+
+Shall be responsible for placing and removing societies from probationary and suspended status and for all correspondence contained therewith.
+
+Shall prepare and distribute a society representatives’ handbook to each representative at the first meeting of each semester.
+
+Shall act as Elections Chairperson.
+
+Shall select and chair the Engineering Council Representatives’ Committee in accordance to the provisions in Bylaws.
+
+Shall be responsible for the planning and execution of any Engineering Council delegation for Conferences
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester
+
+## Section 3: Director of Leadership
+
+Shall chair the Engineering Leadership Committee, in accordance to the provisions in Bylaws, which will plan the Engineering Student Leadership Retreat
+
+Shall provide leadership training to the Executive Board and shall be responsible for planning retreats with the aid of the President.
+
+Shall provide leadership training and consulting services to the member societies as well as other organizations which may be struggling and seek to improve.
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester
+
+## Section 4: Director of Administration
+
+Shall establish and maintain a database of Council presidents and representatives.
+
+Shall monitor and update the Engineering Council representatives and Society Presidents mailing lists.
+
+Shall be responsible for developing and maintaining the Engineering Council website
+
+Shall be responsible for computing resources of the Engineering Council.
+
+Shall maintain records of each society’s Membership Obligations efforts as mandated by the Article VII.
+
+Shall be responsible for taking attendance at General Meetings
+
+Shall take roll and shall determine if a quorum is present at each meeting of Engineering Council if a vote is to be taken
+
+Shall keep a permanent record of the minutes of each Engineering Council general meeting and shall make them available to Member Societies on the Engineering Council webpage
+
+Shall take minutes at all Executive Board meetings and maintain a permanent record of these minutes and distribute the minutes to all Executive Board members.
+
+Shall compile officer reports before each executive board meeting.
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester.
+
+## Section 5: Director of Corporate Affairs
+
+Shall establish and maintain an Engineering Council corporate database.
+
+Shall establish and maintain solicitation documents for corporate funding
+
+Shall establish a standard level system for corporate funding
+
+If necessary, shall solicit corporate funds with permission of the Engineering Council President
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester
+
+## Section 6: Director of Finance
+
+Shall review, monitor and accept responsibility for the financial matters of the Engineering Council.
+
+Shall keep accurate and permanent records of financial transactions of Council and keep the President informed of the financial status of Engineering Council.
+
+Shall be responsible for keeping records of the Engineering Council Funds and shall ensure that societies fulfill the funding obligations set forth in the funding applications.
+
+Shall compile officer reports before each executive board meeting.
+
+Shall coordinate corporate funding with Corporate Director
+
+## Section 7: Director of Student Affairs
+
+Shall establish and chair the Engineering Council Student Affairs Committee in accordance with the Bylaws. 
+
+Shall act as a vital input into the administration of the College of Engineering in areas of student interest.
+
+Shall assist the College in creating, reviewing, and evaluating proposals that relate to engineering curricula or student life.
+
+Shall provide a source of information to the Engineering Council and the MSA Engineering Student Representatives, so that they may be aware of prevailing student opinion.
+
+Shall always be cognizant of the concerns of the engineering student body and shall:
+
+- Develop a program for communication between the Engineering Council and the engineering student body;
+- Have an open door policy that will allow any engineering student to appear before the committee to air a grievance or suggest a new idea.
+
+Shall research and initiate new programs and events to the benefit of engineering students.
+
+Shall schedule a Town Hall Meeting each semester with the Dean, Associate Deans, and relevant College personnel for the time, place, and date of the meeting; this information shall be made available to all engineering students.
+
+## Section 8: Director of Publicity
+ 
+Shall establish and chair the Publicity Committee in accordance with the Bylaws.
+
+Shall issue news releases of Council actions and accomplishments.
+
+Shall be responsible for public relations of Engineering Council with the university and surrounding communities.
+
+Shall maintain the Events Calendar for the Engineering Council and Member Societies.
+
+Shall establish a committee in accordance to the provisions in Bylaws to publicize the events of Engineering Council and any other events or news deemed necessary by the President.
+
+Shall publicize all upcoming Engineering Council general meetings.
+
+Shall be responsible for all Engineering Council announcements
+
+Shall be responsible for the UMEC Newsletter
+
+Shall be responsible for the planning, production, and distribution of the Engineering Student Planner.
+
+Shall coordinate solicitation of funding with the Corporate Director
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester.
+
+## Section 9: Director of Social Affairs
+
+Shall be responsible for chairing and the establishment of the Engineering Council Social Affairs Committee, in accordance with the Bylaws.
+
+Shall be responsible for the planning and execution of Springfest, Welcome Day, and all other social events deemed necessary by the Executive Board.
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester.
+
+Shall coordinate funding for events with Corporate Director
+
+## Section 10: Director of Honors and Service
+
+Shall be responsible for establishment of the Engineering Council Honors and Service Committee.
+
+Shall be Chairperson of the Engineering Council Honors and Service Committee.
+
+Shall be responsible for organizing and executing the North Campus Service Day
+
+Shall be responsible for the planning and execution of events to facilitate interaction with first year students and transfer students.
+
+Shall coordinate planning and execution of service and first year student events with the Engineering Advising Center and Director of Leadership
+
+Shall establish and chair the Engineering Council Honors and Service Committee in accordance with the Bylaws
+
+Shall be responsible for the planning and execution of the Order of the Engineer Ceremony.
+
+Shall be responsible for submitting an itemized budget to the Director of Finance by the end of each semester.
+
+Shall coordinate funding with Corporate Director
+
+## Section 11: NAESC, Inc. Exec Board Members
+
+Shall be involved in weekly online or phone meetings with NAESC Exec Board and planning of the NAESC national conference.
+
+Shall represent UMEC well while on the NAESC Executive Board.
+
+Shall assist all engineering councils, including UMEC, in any possible way, especially in terms of funding for the NAESC national conference.
+
+Shall report their progress and NAESC related activities to General Council at least once every two General Body meetings.
+
+# Article VI: COMMITTEES
+
+## Section 1:  Engineering Leadership Committee (ELC)
+
+Shall be the standing committee of the Director of Leadership.
+
+Shall organize the Engineering Student Leadership Retreat, to be held early in the semester.  The purpose of the retreat shall be to train all participants in leadership techniques as well as to improve upon the collaborative efforts among the Engineering Council member societies and the College of Engineering administration.
+
+Shall pursue and organize any other events that would enhance the leadership capabilities of the students in the College of Engineering.
+
+Shall provide leadership training to the Executive Board of the Engineering Council
+
+
+## Section 2:  Student Affairs Committee
+
+Shall be the standing committee of the Student Affairs Director.
+
+Shall act as a vital input into the administration of the College ofEngineering in areas of student interest.
+
+Shall assist the College in creating, reviewing, and evaluating proposalsthat relate to curricula or student life of engineering students.
+
+Shall appoint committee member(s) to:
+
+- Pierpont Commons,
+- Duderstadt Center,
+- Curriculum,
+- Computer Aided Engineering Network (CAEN), to represent the interests of College of Engineering students and the Engineering Council.
+
+Shall provide a source of information to the Engineering Council and the CSG Engineering Student Representatives, so that they may be aware of prevailing student opinion.
+
+Shall always be cognizant of the concerns of the engineering student bodyand shall:
+
+- Develop a program for communication between the Engineering Council andthe engineering student body;
+- Have an open door policy that will allow any engineeringstudent to appear before the committee to air a grievance or suggest a newidea.
+
+Shall research and initiate new programs to thebenefit of engineering students.
+
+Shall host events involving bothengineering students and faculty and/or administration to promote communicationin the students’ interest.
+
+Shall organize Town Hall Meetings at least once per semester as per theStudent Affair Director Bylaws.
+
+Thecommittee shall be chosen by the Student Affairs Committee Director by bothpetitions and interviews. The President of Engineering Council may also help inthe selection of the committee if both the Dean's Student Advisory Director andthe President agree.
+
+## Section 3:  Engineering Council Honors and Service Committee
+
+Shall organize and recruit volunteers in addition to planning and executing North Campus Service Day.
+
+Shall constantly solicit and analyze feedback from parties involved in the aforementioned programs.
+
+There shall be an Engineering Council Honors and Service Committee which shall be responsible for the establishment of the awards for societies and students.  
+
+Every award shall be selected by an Honors and Service committee comprised of at least 7 students who represent a random distribution of engineering students in all departments. Members of the Executive Board shall fill in if this minimum is not met.
+
+The Engineering Council Honors and Service Committee shall distribute nomination forms for the Honors and Service to all department offices.
+
+The Engineering Council Honors and Service Committee shall be responsible for determining the eligibility of all candidates through the College of Engineering Associate Dean’s Office.
+
+The Engineering Council Honors and Service Committee shall be responsible for researching all eligible candidates.
+
+Should no candidate or society be deemed worthy, it shall be the prerogative of the Honors and Service Committee to refrain from presenting any or all of its awards in a given year.
+
+The Engineering Council Honors and Service Committee shall be charged with accurately polling students and assessing advisors across the College of Engineering for award nominations.
+
+## Section 4:  Engineering Council Publicity Committee
+
+Shall be the standing committee of the Publicity Chair.
+
+Shall be responsible for all publicity of Engineering Council meetings.
+
+Shall be responsible for UMEC Newsletter
+
+Shall maintain the web calendar of all Engineering Council and member society events.
+
+Shall be responsible for all publicity of Engineering Council events at the request of Executive Board members.
+
+Shall be responsible for publicizing Engineering Council during Engineering Council events in consultation with the Director of said event with reasonable and customary notice.
+
+Shall be responsible for coordinating the pictures during all Engineering Council events.
+
+## Section 5:  Engineering Council Social Affairs Committee
+
+Shall be the standing committee of the Social Affairs Chair.
+
+- Shall be responsible for enacting programs of a general nature and worth to the engineering student body. The character of these programs shall be of a non-academic nature and shall encourage fellowship and revelry among the students of the College of Engineering.
+
+Shall be responsible for organizing Springfest which will be held on the last day of classes in the Winter semester.
+
+Shall be responsible for organizing Welcome Day.
+
+Shall work with Corporate Director to solicit corporate sponsorship for events.
+
+## Section 6:  Engineering Council Representative Committee
+
+Shall assist the Vice President with the development of programming and content for General Meetings.
+
+Shall be comprised of Society Representatives.
+
+# Article VIII: MEMBER SOCIETY OBLIGATIONS
+
+## Society Representative
+
+- Every Engineering Council member society must have at least one representative.
+- A representative may represent only one society.
+- The representative is responsible for ensuring that the society he/she represents fulfills the obligations set forth in the UMEC ByLaws and UMEC Constitution.
+
+## General Meetings
+
+- The society representative must attend all general meetings; otherwise, they must send a substitute or be excused by the Vice President.
+- The society representative is responsible for reporting all information from the general meetings to the society that he/she represents.
+
+## Communication
+
+- Representatives must report Engineering Council events, and the events of other societies presented to them, to their societies. Representatives must also report their societies’ events to Engineering Council.
+- The change of officer form must be completed when the members of the executive board of a society change.
+
+## Probation and Suspension
+
+- In the event that a society does not fulfill the obligations, the represented society will be placed on probationary status as detailed in Article VIII of the Bylaws.
+
+# Article IX: MEMBER SOCIETY PROBATION/SUSPENSION
+
+## Section 1:
+
+Society status will be defined as Good, Probation, or Suspension.
+
+A society will be given a status for a term of one semester, based on a society’s UMEC involvement for the previous semester. At the end of each semester, societies will be notified by the Vice President of their status for the following semester within two weeks of the last General Body Meeting of the current semester. Throughout the semester, it is the society’s responsibility to ensure their fulfillment of the obligations set forth in Article VIII: MEMBER SOCIETY OBLIGATIONS. A semester is defined as an academic term (Fall and Winter) as scheduled by the Registrar.
+
+Societies in Good standing will have use of all UMEC services. If a society fulfills all obligations stated in Article VIII during the current semester, the society will be placed in Good standing for the following semester. If a society does not fulfill these obligations, the society will be placed on Probation for the following semester.
+
+Societies newly registering with UMEC and societies registering after one or more terms of Suspension shall be placed on Probation for the term during which they register. While on Probation, a society will have use of all UMEC services. If during the semester on Probation, a society fulfills the obligations stated in Article VIII, the society will be placed in Good standing for the following semester. If during the semester on Probation a society does not fulfill all obligations, the society will be placed on Suspension.
+
+Societies on Suspension will not have use of UMEC services and will not be considered to have any affiliation with UMEC. Therefore, following the semester a society spends on Suspension, the society will be welcome to register with UMEC as a new member society.
+
+A society may petition to the Vice President at any time to change their status. The petition will be voted on by the General Body at the General Body meeting following the petition. A two-thirds majority vote is required to change the status of a society.  This status change affects the status for the remainder of the current semester.  When determining status for the following semester, UMEC will consider the most recent society status only.
+
+# Article X: BUDGETARY PROCEDURES
+
+## Section 1:
+
+At the beginning of each semester the Director of Finance is required to present his/her suggested budget for the upcoming semester. From this information a finalized budget must be discussed and approved by the Executive Board prior to the Allocation’s Meeting for that semester.
+
+## Section 2:
+
+Any budget which is adopted by Engineering Council at the beginning of each semester must leave an end-of-semester balance reflecting liabilities as follows:
+
+At the end of any fall semester, a balance of not less than 10% of the student assessments received by Engineering Council at the beginning of that semester. At the end of any winter semester, a positive balance.
+
+## Section 3:
+
+No expenditures may be made nor allocations passed which exceed the amounts set forth for them in the budget, unless these over-budget expenditures are approved by the entire Executive Board. Also adjustments need to be concurrently made in the budget for that term such that the end-of-term balance follows that outlined in Section 2 above.
+
+# Article XI: FUNDING POLICY
+
+## Section 1: Eligibility
+
+The Engineering Council only provides funding for engineering societies as recognized under Article I, Section 2.
+
+## Section 2:
+
+Societies must have a Representative present at every General Body meeting of the current semester, including the Student Organization Retreat.
+
+Societies must also have completed the allocations report from the previous semester, where applicable. The date that this report needs to be submitted to the Director of Finance will be determined by him/her and announced at a Treasurers’ Meeting at the beginning of the semester and will be announced to the Engineering Council at UMEC General Meetings throughout the semester. This report is to include:
+
+- Information about how the money was spent 
+- How much was requested and how much was allocated 
+- How the event met the goals 1-11 described in part E below 
+- Copies of the publicity which must state "sponsored in part by the University of Michigan Engineering Council"
+
+The Engineering Council will not provide funding for an event which makes money. If a sponsored event does make money, the allocation will be considered a loan to be paid back immediately after the event occurs.
+
+The Engineering Council will not sponsor events serving alcoholic beverages in compliance with the University alcohol policy.
+
+The following factors will be taken into account when distributing the funds:
+
+- Degree of participation in the Council 
+- Past accountability of the society or organization
+- The role of Engineering students in the activity 
+- Ideas targeted toward first year students
+- Ideas involving collaboration with other engineering societies
+- New ideas 
+- Ideas which improve technical education 
+- Ideas which improve social awareness or social concern 
+- Ideas which promote the College of Engineering 
+- Ideas which are difficult to fund by other means 
+- The attempt to find other funding sources 
+- Access to other funding options
+
+## Section 3: The Funding Committee
+
+The Director of Finance shall be responsible for forming the Funding Committee at the beginning of each semester and administering its meetings on a regular schedule.
+
+All allocations decisions shall be made during Funding Committee meetings and with no fewer than four Funding Committee members participating in the decision. 
+
+The policies of the Funding Committee and its administration shall be made available, by the Director of Finance, on the UMEC web site. Violations of the funding policy set forth by the Director of Finance shall be considered violations of the By-Laws of the University of Michigan Engineering Council.
+
+# Article XII: MICHIGAN STUDENT ASSEMBLY
+
+## Section 1: Tenure
+
+Should a vacancy occur in one of the CSG positions of the Engineering College, the General Council shall elect, at the UMEC General Body Meeting after notification, a new representative to serve out the rest of the term in the seat vacated. This election shall require a majority vote. Any representative appointed shall be liable to be recalled at any time remaining in that term by a majority vote of the General Council, if he/she is not serving the duties required by their position. The representative must serve on the Student Affairs Committee in the Council during their term as a representative of the Engineering College in CSG.
+
+# Article XIII: INSIGNIA
+
+## Section 1: Use of the UMEC Name
+
+The term “UMEC” may be used in regards to any business officially or unofficially related to the Council. In official Council communications and publications, the full title “University of Michigan Engineering Council” shall be used when possible.
+
+The Council may also be referred to as “Engineering Council” or “U of M Engineering Council.” All other references shall be avoided when used for official business.
+
+## Section 2: UMEC Seal
+
+An official Seal shall represent the Council. The seal shall carry the title “University of Michigan Engineering Council,” and the seal shall denote “1927” as the year of the Council’s establishment.
+
+The Council shall use the Seal in all official communications, where deemed appropriate.
+
+The official Seal shall be in circular shape, with UMEC’s title and founding year within its outer boundary.
+
+A valid copy of the official Seal shall be kept by the Director of Administration. The official Seal may only be altered with the majority vote of the Council.
+
+## Section 3: UMEC Logo
+
+An official Logo shall represent the Council. The logo shall carry the term “UMEC,” and should denote “1927” as the year of the Council’s establishment.
+
+The Council should use the Logo in all communications, where deemed appropriate.
+
+The official Logo shall consist of the block letters “UMEC” in alternating blue and gold colors, with the words “EST. 1927” in black bold lettering centered between the M and E of “UMEC.” There shall be a blue bold underline to the title, with “University of Michigan Engineering Council” in full bold and blue text under the line.
+
+A valid copy of the official Logo shall be kept by the Director of Administration. The official Logo may be altered with a majority vote of the Council. 
+
+# Article XIV: AMENDMENTS
+
+Amendments to these ByLaws require a majority vote of the Tenured membership. Voting can only take place after the amendments made have been presented to the General Body in written and oral documentation.

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <h2>About Us:</h2>
         <ul class='category'>
           <li><a href='/constitution.html'>Our Constitution</a></li>
-          <li>Our By-Laws</li>
+          <li><a href='/by-laws.html'>Our By-Laws</a></li>
           <li>The Current Board</li>
           <li>&nbsp;<!-- I'm empty to make border longer --></li>
           <li>&nbsp;<!-- I'm empty to make border longer --></li>


### PR DESCRIPTION
I've made the **breaking** change to remove sub-sub sections because I want uniformity with our constitution and our constitution doesn't have sub-sub sections.

@rpolik, @clharman informs me you want to know my process. Each document is slightly different. The goal is to get the content in plain text first. So for our constitution I went from pdf->word document->plain text, whereas for the by-laws I literally copy and pasted into a text editor.

Once in plain text, the process is again different for each document. Simply find patterns in the text and convert them to markdown. Know your text editor. It can make things an order of magnitude faster.

This sounds tedious, but it took me longer to write this than to create our by-laws in markdown.

Any questions? If not, merge this pull request.
