### PR TITLE
Add executive board page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -46,3 +46,8 @@ a {
     color: #79BD8F;
     text-decoration: none;
 }
+
+iframe {
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+}

--- a/executive-board.html
+++ b/executive-board.html
@@ -1,0 +1,86 @@
+<html>
+  <head>
+    <title>UMEC: Executive Board</title>
+    <!-- @include includes/head.html -->
+  </head>
+  <body>
+    <!-- @include includes/header.html -->
+    <div class='content'>
+      <h1>UMEC Executive Board</h1> 
+      <table class='pure-table pure-table-striped'>
+        <thead>
+          <tr>
+            <th>Position</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Office Hours (1222 EECS)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>President</td>
+            <td>Max Olender</td>
+            <td>umec.pres@umich.edu</td>
+            <td>Wed 12-1pm</td>
+          </tr>
+          <tr>
+            <td>Vice President</td>
+            <td>David Hershey</td>
+            <td>umec.vp@umich.edu</td>
+            <td>Mon 3-4pm</td>
+          </tr>
+          <tr>
+            <td>Director of Administration</td>
+            <td>Colin Harman</td>
+            <td>umec.doa@umich.edu</td>
+            <td>Tue 3-4pm</td>
+          </tr>
+          <tr>
+            <td>Director of Leadership</td>
+            <td>Neal Parikh</td>
+            <td>umec.dol@umich.edu</td>
+            <td>Thu 11am-12pm</td>
+          </tr>
+          <tr>
+            <td>Director of Corporate Affairs</td>
+            <td>James Glantz</td>
+            <td>umec.corpdir@umich.edu</td>
+            <td>Tue 12-1pm</td>
+          </tr>
+          <tr>
+            <td>Director of Finance</td>
+            <td>Nick Babcock</td>
+            <td>umec.dof@umich.edu</td>
+            <td>Fri 12:30-1:30pm</td>
+          </tr>
+          <tr>
+            <td>Director of Student Affairs</td>
+            <td>Adam Schroeder</td>
+            <td>umec.studaff@umich.edu</td>
+            <td>Fri 1:30-2:30pm</td>
+          </tr>
+          <tr>
+            <td>Director of Publicity</td>
+            <td>Robert Polik</td>
+            <td>umec.pub@umich.edu</td>
+            <td>Mon 2-3pm</td>
+          </tr>
+          <tr>
+            <td>Director of Social Affairs</td>
+            <td>Brigid McNamara</td>
+            <td>umec.soc@umich.edu</td>
+            <td>Wed 1-2pm</td>
+          </tr>
+          <tr>
+            <td>Director of Honors and Service</td>
+            <td>Sophie Hardig</td>
+            <td>umec.has@umich.edu</td>
+            <td>Tue 1-2pm</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <iframe src="http://www.google.com/calendar/embed?src=umich.edu_art9335slb7bf6qsgomrqkeptg@group.calendar.google.com&amp;color=%23668CD9&amp;mode=WEEK&amp;ctz=America/Detroit&amp;showTitle=1&amp;showNav=1&amp;showDate=1&amp;showTabs=1&amp;showCalendars=0&amp;hl=en" title="UMEC Office Hours" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <ul class='category'>
           <li><a href='/constitution.html'>Our Constitution</a></li>
           <li><a href='/by-laws.html'>Our By-Laws</a></li>
-          <li>The Current Board</li>
+          <li><a href='/executive-board.html'>The Executive Board</a></li>
           <li>&nbsp;<!-- I'm empty to make border longer --></li>
           <li>&nbsp;<!-- I'm empty to make border longer --></li>
           <li>&nbsp;<!-- I'm empty to make border longer --></li>


### PR DESCRIPTION
I had a second so I decided to implement the executive board information.  I think this is all that is needed. Personally, we don't need any of this: http://umec.engin.umich.edu/home/who-we-are/exec-board

I was able to embed an iframe with our office hours g-calendar without any problems. So @clharman, you should be good to go for your events calendar. 

Edit: Related #5, #4 
