### PR TITLE
Add studaff

### DIFF
--- a/content/committees.md
+++ b/content/committees.md
@@ -4,9 +4,9 @@
 
 - [Funding](#funding)
 - [Leadership](#leadership)
-- [Honors and Services](#honors and service)
+- [Honors and Services](#honors-and-service)
 - [Publicity](#publicity)
-- [Student Affairs](#student affairs)
+- [Student Affairs](#student-affairs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Added student affairs committee info.  Changed some minor wording issues in committees.md (e.g. Honors and Service, not Honor and Services).  Problem: Student Affairs and Honors and Service links do not work.  it must have to do with the spaces.  How do we fix this?
